### PR TITLE
cache schema as dedicated subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ vi local.yml # update accordingly
 
 pywis-pubsub --version
 
+# cache WIS2 notification schema
+pywis-pubsub schema cache
+
 # connect, and simply echo messages
 pywis-pubsub subscribe --config local.yml
 

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ vi local.yml # update accordingly
 
 pywis-pubsub --version
 
-# cache WIS2 notification schema
-pywis-pubsub schema cache
+# sync WIS2 notification schema
+pywis-pubsub schema sync
 
 # connect, and simply echo messages
 pywis-pubsub subscribe --config local.yml

--- a/pywis_pubsub/__init__.py
+++ b/pywis_pubsub/__init__.py
@@ -24,6 +24,7 @@ __version__ = '0.1.1'
 import click
 
 from pywis_pubsub.subscribe import subscribe
+from pywis_pubsub.schema import schema
 
 
 @click.group()
@@ -33,4 +34,5 @@ def cli():
     pass
 
 
+cli.add_command(schema)
 cli.add_command(subscribe)

--- a/pywis_pubsub/schema.py
+++ b/pywis_pubsub/schema.py
@@ -33,9 +33,11 @@ USERDIR = Path.home() / '.pywis-pubsub'
 MESSAGE_SCHEMA = USERDIR / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa
 
 
-def cache_schema():
+def cache_schema() -> None:
     """
-    Cache WIS2 notification schema:w
+    Cache WIS2 notification schema
+
+    :returns: `None`
     """
 
     LOGGER.debug('Caching notification message schema')

--- a/pywis_pubsub/schema.py
+++ b/pywis_pubsub/schema.py
@@ -1,0 +1,68 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+import click
+import logging
+from pathlib import Path
+from urllib.request import urlopen
+
+from pywis_pubsub import cli_options
+
+LOGGER = logging.getLogger(__name__)
+
+MESSAGE_SCHEMA_URL = 'https://raw.githubusercontent.com/wmo-im/wis2-notification-message/main/WIS2_Message_Format_Schema.yaml'  # noqa
+USERDIR = Path.home() / '.pywis-pubsub'
+MESSAGE_SCHEMA = USERDIR / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa
+
+
+def cache_schema():
+    """
+    Cache WIS2 notification schema:w
+    """
+
+    LOGGER.debug('Caching notification message schema')
+
+    if not MESSAGE_SCHEMA.parent.exists():
+        LOGGER.debug(f'Creating cache directory {MESSAGE_SCHEMA.parent}')
+        MESSAGE_SCHEMA.parent.mkdir(parents=True, exist_ok=True)
+
+    LOGGER.debug('Downloading message schema')
+    with MESSAGE_SCHEMA.open('wb') as fh:
+        fh.write(urlopen(MESSAGE_SCHEMA_URL).read())
+
+
+@click.group()
+def schema():
+    """Notification schema management"""
+    pass
+
+
+@click.command()
+@click.pass_context
+@cli_options.OPTION_VERBOSITY
+def cache(ctx, verbosity):
+    """Cache WIS2 notification schema"""
+
+    click.echo('Caching notification message schema')
+    cache_schema()
+
+
+schema.add_command(cache)

--- a/pywis_pubsub/schema.py
+++ b/pywis_pubsub/schema.py
@@ -22,6 +22,7 @@
 import click
 import logging
 from pathlib import Path
+import shutil
 from urllib.request import urlopen
 
 from pywis_pubsub import cli_options
@@ -33,18 +34,19 @@ USERDIR = Path.home() / '.pywis-pubsub'
 MESSAGE_SCHEMA = USERDIR / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa
 
 
-def cache_schema() -> None:
+def sync_schema() -> None:
     """
-    Cache WIS2 notification schema
+    Sync WIS2 notification schema
 
     :returns: `None`
     """
 
-    LOGGER.debug('Caching notification message schema')
+    LOGGER.debug('Syncing notification message schema')
 
-    if not MESSAGE_SCHEMA.parent.exists():
-        LOGGER.debug(f'Creating cache directory {MESSAGE_SCHEMA.parent}')
-        MESSAGE_SCHEMA.parent.mkdir(parents=True, exist_ok=True)
+    if MESSAGE_SCHEMA.parent.exists():
+        shutil.rmtree(USERDIR)
+
+    MESSAGE_SCHEMA.parent.mkdir(parents=True, exist_ok=True)
 
     LOGGER.debug('Downloading message schema')
     with MESSAGE_SCHEMA.open('wb') as fh:
@@ -60,11 +62,11 @@ def schema():
 @click.command()
 @click.pass_context
 @cli_options.OPTION_VERBOSITY
-def cache(ctx, verbosity):
-    """Cache WIS2 notification schema"""
+def sync(ctx, verbosity):
+    """Sync WIS2 notification schema"""
 
-    click.echo('Caching notification message schema')
-    cache_schema()
+    click.echo('Syncing notification message schema')
+    sync_schema()
 
 
-schema.add_command(cache)
+schema.add_command(sync)

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -209,12 +209,16 @@ def on_message_handler(client, userdata, msg):
     msg_dict = json.loads(msg.payload)
     msg_json = json.dumps(msg_dict, indent=4)
 
-    if userdata.get('validate_message', False):
-        LOGGER.debug('Validating message')
-        success, err = validate_message(msg_dict)
-        if not success:
-            LOGGER.error(f'Message is not a valid notification: {err}')
-            return
+    try:
+        if userdata.get('validate_message', False):
+            LOGGER.debug('Validating message')
+            success, err = validate_message(msg_dict)
+            if not success:
+                LOGGER.error(f'Message is not a valid notification: {err}')
+                return
+    except RuntimeError as err:
+        LOGGER.error(f'Cannot validate message: {err}')
+        return
 
     LOGGER.debug(f'Topic: {msg.topic}')
     LOGGER.debug(f'Raw message:\n{msg_json}')

--- a/pywis_pubsub/util.py
+++ b/pywis_pubsub/util.py
@@ -155,5 +155,3 @@ def get_userdir() -> str:
     """
 
     return Path.home() / '.pywis-pubsub'
-
-MESSAGE_SCHEMA = get_userdir() / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa

--- a/pywis_pubsub/validation.py
+++ b/pywis_pubsub/validation.py
@@ -24,7 +24,8 @@ from typing import Tuple
 
 from jsonschema import validate
 
-from pywis_pubsub.util import MESSAGE_SCHEMA, yaml_load
+from pywis_pubsub.schema import MESSAGE_SCHEMA
+from pywis_pubsub.util import yaml_load
 
 LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +42,11 @@ def validate_message(instance: dict) -> Tuple[bool, str]:
 
     success = False
     error_message = None
+
+    if not MESSAGE_SCHEMA.exists():
+        msg = 'Schema not found. Please run pywis-pubsub schema cache'
+        LOGGER.error(msg)
+        raise RuntimeError(msg)
 
     with open(MESSAGE_SCHEMA) as fh:
         schema = yaml_load(fh)

--- a/pywis_pubsub/validation.py
+++ b/pywis_pubsub/validation.py
@@ -44,7 +44,7 @@ def validate_message(instance: dict) -> Tuple[bool, str]:
     error_message = None
 
     if not MESSAGE_SCHEMA.exists():
-        msg = 'Schema not found. Please run pywis-pubsub schema cache'
+        msg = 'Schema not found. Please run pywis-pubsub schema sync'
         LOGGER.error(msg)
         raise RuntimeError(msg)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ from pathlib import Path
 import re
 from setuptools import Command, find_packages, setup
 import sys
-from urllib.request import urlopen
 
 
 class PyTest(Command):
@@ -69,21 +68,6 @@ MANIFEST = Path('MANIFEST')
 
 if MANIFEST.exists():
     MANIFEST.unlink()
-
-print('Caching notification message schema')
-
-MESSAGE_SCHEMA_URL = 'https://raw.githubusercontent.com/wmo-im/wis2-notification-message/main/WIS2_Message_Format_Schema.yaml'  # noqa
-
-USERDIR = Path.home() / '.pywis-pubsub'
-MESSAGE_SCHEMA = USERDIR / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa
-
-
-if not MESSAGE_SCHEMA.parent.exists():
-    print('Downloading message schema')
-    MESSAGE_SCHEMA.parent.mkdir(parents=True, exist_ok=True)
-
-    with MESSAGE_SCHEMA.open('wb') as fh:
-        fh.write(urlopen(MESSAGE_SCHEMA_URL).read())
 
 
 setup(


### PR DESCRIPTION
setuptools / pip3 workflow forbids external caching (while the same works via `python3 setup.py install`).  Move schema caching to design time.