### PR TITLE
pin Shapely requirement, update notification schema location

### DIFF
--- a/pywis_pubsub/schema.py
+++ b/pywis_pubsub/schema.py
@@ -29,7 +29,7 @@ from pywis_pubsub import cli_options
 
 LOGGER = logging.getLogger(__name__)
 
-MESSAGE_SCHEMA_URL = 'https://raw.githubusercontent.com/wmo-im/wis2-notification-message/main/WIS2_Message_Format_Schema.yaml'  # noqa
+MESSAGE_SCHEMA_URL = 'https://raw.githubusercontent.com/wmo-im/wis2-notification-message/main/schemas/notificationMessageGeoJSON.yaml'  # noqa
 USERDIR = Path.home() / '.pywis-pubsub'
 MESSAGE_SCHEMA = USERDIR / 'wis2-notification-message' / 'WIS2_Message_Format_Schema.yaml'  # noqa
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ jsonschema
 paho-mqtt
 pyyaml
 requests
-shapely
+shapely<2


### PR DESCRIPTION
Shapely 2.0 has been released which increases the the install footprint with functionality not used by pywis-pubsub.  Given it is a major release, this PR pins to the latest stable 1.x.

This PR also updates the location of the notification message schema for cache/sync.