### PR TITLE
add hook functionality

### DIFF
--- a/pywis-pubsub-config.yml
+++ b/pywis-pubsub-config.yml
@@ -25,6 +25,15 @@ storage:
 #        url: http://localhost:9001
 #        bucket: some-bucket
 
+# advanced functionality: add your own code/workflow/trigger
+#
+# hook: # trigger that implements pywis-pubsub Hook (pywis_pubsub.hook.Hook)
+#
+# test hook available from pywis_pubsub.hook.TestHook
+#hook: pywis_pubsub.hook.TestHook
+
+
+
 # added for mqp-subscriber
 wis2box: true
 


### PR DESCRIPTION
This PR adds the ability to add custom hooks for Python developers to integrate workflow.

Assumes 1 hook per configuration.  The code could be updated to support 1 hook per topic if desired.