### PR TITLE
make storage path configurable based on data_id or canonical link

### DIFF
--- a/.github/workflows/test-data/sub-no-msg-validation.yml
+++ b/.github/workflows/test-data/sub-no-msg-validation.yml
@@ -16,4 +16,4 @@ validate_message: false
 storage:
     type: fs
     options:
-        path: .github/workflows/test-data/
+        basedir: .github/workflows/test-data/

--- a/.github/workflows/test-data/sub-with-msg-validation.yml
+++ b/.github/workflows/test-data/sub-with-msg-validation.yml
@@ -16,4 +16,4 @@ validate_message: true
 storage:
     type: fs
     options:
-        path: .github/workflows/test-data/
+        basedir: .github/workflows/test-data/

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ from pywis_pubsub.mqtt import MQTTPubSubClient
 options = {
     'storage': {
         'type': 'fs',
-        'path': '/tmp'
+        'basedir': '/tmp'
     },
     'bbox': [-90, -180, 90, 180]
 }

--- a/pywis-pubsub-config.yml
+++ b/pywis-pubsub-config.yml
@@ -28,7 +28,11 @@ validate_message: true
 storage:
     type: fs
     options:
-        path: /tmp/foo/bar
+        basedir: /tmp/foo/bar
+        # filepath can be one of:
+        # - data_id: 'properties.data_id' in the message (default)
+        # - link: the local path in the canonical link
+        filepath: data_id, link
 
 # storage: s3
 #storage:

--- a/pywis-pubsub-config.yml
+++ b/pywis-pubsub-config.yml
@@ -32,7 +32,8 @@ storage:
         # filepath can be one of:
         # - data_id: 'properties.data_id' in the message (default)
         # - link: the local path in the canonical link
-        filepath: data_id, link
+        # - combined: data_id + file extension either from link or guessing the media type
+        filepath: data_id
 
 # storage: s3
 #storage:

--- a/pywis_pubsub/message.py
+++ b/pywis_pubsub/message.py
@@ -30,7 +30,7 @@ from pywis_pubsub.util import get_http_session
 LOGGER = logging.getLogger(__name__)
 
 
-def get_canonical_link(links: list):
+def get_canonical_link(links: list) -> dict:
     """
     Helper function to derive canonical link from a list of link objects
 

--- a/pywis_pubsub/storage.py
+++ b/pywis_pubsub/storage.py
@@ -49,7 +49,7 @@ class Storage(ABC):
 class FileSystem(Storage):
     def save(self, data: bytes, filename: Path) -> bool:
 
-        filepath = Path(self.options['path']) / filename
+        filepath = Path(self.options['basedir']) / filename
 
         LOGGER.debug(f'Creating directory {filepath.parent}')
         filepath.parent.mkdir(parents=True, exist_ok=True)

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -98,7 +98,17 @@ def on_message_handler(client, userdata, msg):
             else:
                 LOGGER.debug('Data verification passed')
 
-        filename = msg_dict['properties']['data_id']
+        filepath = userdata['storage']['options'].get('filepath', 'data_id')
+        LOGGER.debug(f'Using {filepath} for naming filepath')
+
+        if filepath == 'link':
+            # fetch canonical link and use local path, stripping slashes
+            link = get_canonical_link(msg_dict['links'])
+            filename = link['href'].split('/', 3)[-1].strip('/')
+        else:
+            filename = msg_dict['properties']['data_id']
+
+        LOGGER.debug(f'filename: {filename}')
 
         storage_class = STORAGES[userdata.get('storage').get('type')]
         storage_object = storage_class(userdata['storage'])

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -21,6 +21,7 @@
 
 import json
 import logging
+from pathlib import Path
 import random
 
 import click
@@ -102,10 +103,30 @@ def on_message_handler(client, userdata, msg):
         LOGGER.debug(f'Using {filepath} for naming filepath')
 
         if filepath == 'link':
+            LOGGER.debug('Using canonical link as filepath')
             # fetch canonical link and use local path, stripping slashes
             link = get_canonical_link(msg_dict['links'])
             filename = link['href'].split('/', 3)[-1].strip('/')
+        elif filepath == 'combined':
+            LOGGER.debug('Using combined data_id+link extension as filepath')
+            filename = msg_dict['properties']['data_id']
+            suffix = Path(get_canonical_link(msg_dict['links'])).suffix
+            if suffix != '':
+                LOGGER.debug(f'File extension found: {suffix}')
+                filename = f'{filename}{suffix}'
+            else:
+                LOGGER.debug('File extension not found. Trying media type')
+                media_type = get_canonical_link(msg_dict['links']).get('type')
+                if media_type is not None:
+                    suffix = util.guess_extension(media_type)
+                    if suffix is not None:
+                        filename = f'{filename}{suffix}'
+                    else:
+                        LOGGER.debug('No extension found. Giving up / using data_id')  # noqa
+                else:
+                    LOGGER.debug('No media type found. Giving up / using data_id')  # noqa
         else:
+            LOGGER.debug('Using data_id as filepath')
             filename = msg_dict['properties']['data_id']
 
         LOGGER.debug(f'filename: {filename}')

--- a/pywis_pubsub/util.py
+++ b/pywis_pubsub/util.py
@@ -23,6 +23,7 @@ from base64 import b64encode
 from datetime import date, datetime, time
 from decimal import Decimal
 import logging
+import mimetypes
 import os
 from pathlib import Path
 import re
@@ -179,3 +180,29 @@ def get_http_session():
     s.mount('http://', adapter)
 
     return s
+
+
+def guess_extension(media_type: str) -> str:
+    """
+    Guess file extension from known WMO media types:
+
+    :media_type: `str` of media type
+
+    :returns: `str` of file extension
+    """
+
+    extension = None
+
+    wmo_extra_types = {
+        'application/x-bufr': '.bufr4',
+        'application/x-grib': '.grib2',
+        'application/cap+xml': '.cap'
+    }
+
+    for key, value in wmo_extra_types.items():
+        mimetypes.add_type(key, value)
+
+    extension = mimetypes.guess_extension(media_type)
+    LOGGER.debug(f'Found {extension}')
+
+    return extension


### PR DESCRIPTION
When downloading data, the filepath is now configurable based on either `properties.data_id` (default), the canonical link, or a combination of both.  As well, `storage.options.path` is renamed to `storage.options.basedir`.

cc @mgiannoni