### PR TITLE
Added ability to set client_id and clean_session

### DIFF
--- a/pywis-pubsub-config.yml
+++ b/pywis-pubsub-config.yml
@@ -9,6 +9,12 @@ subscribe_topics:
 # topic to publish to
 publish_topic: foo/bar
 
+# mqtt client id - randomly generated if not set
+client_id: pywis-pubsub-testing
+
+# clean mqtt session on connection. Set to false to start from server saved offset
+clean_session: true
+
 # whether to verify data
 verify_data: true
 

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -21,6 +21,7 @@
 
 import json
 import logging
+import random
 
 import click
 
@@ -128,6 +129,7 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     config = util.yaml_load(config)
 
     broker = config.get('broker')
+    client_id = config.get('client_id', f'pywis-pubsub-{random.randint(0, 1000)}')
     qos = int(config.get('qos', 1))
     subscribe_topics = config.get('subscribe_topics', [])
     verify_certs = config.get('verify_certs', True)
@@ -135,6 +137,8 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     options = {
         'verify_certs': verify_certs
     }
+    options['client_id'] = client_id
+    options['clean_session'] = config.get('clean_session', True)
 
     if bbox:
         options['bbox'] = [float(i) for i in bbox.split(',')]

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -129,7 +129,8 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     config = util.yaml_load(config)
 
     broker = config.get('broker')
-    client_id = config.get('client_id', f'pywis-pubsub-{random.randint(0, 1000)}')
+    default_client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
+    client_id = config.get('client_id', default_client_id)
     qos = int(config.get('qos', 1))
     subscribe_topics = config.get('subscribe_topics', [])
     verify_certs = config.get('verify_certs', True)


### PR DESCRIPTION
This allows re-connecting to mqtt server and start consuming messages from last ack'ed message. Without it message consumption will start from beginning each time.

I've documented the two new properties in the pywis-pubsub-config.yml file even though that file seems a little out-of-date.

Thanks!