### PR TITLE
add qos to publish function and example config

### DIFF
--- a/pywis-pubsub-config.yml
+++ b/pywis-pubsub-config.yml
@@ -9,6 +9,9 @@ subscribe_topics:
 # topic to publish to
 publish_topic: foo/bar
 
+# qos (default is 1)
+#qos: 1
+
 # mqtt client id - randomly generated if not set
 client_id: pywis-pubsub-testing
 

--- a/pywis_pubsub/publish.py
+++ b/pywis_pubsub/publish.py
@@ -178,6 +178,7 @@ def publish(ctx, file_, config, url, topic, identifier, geometry=[],
     config = util.yaml_load(config)
 
     broker = config.get('broker')
+    qos = int(config.get('qos', 1))
 
     if topic is None:
         topic2 = config.get('publish_topic')
@@ -202,4 +203,4 @@ def publish(ctx, file_, config, url, topic, identifier, geometry=[],
     client = MQTTPubSubClient(broker)
     click.echo(f'Connected to broker {client.broker_safe_url}')
     click.echo(f'Publishing message to topic={topic2}')
-    client.pub(topic2, json.dumps(message))
+    client.pub(topic2, json.dumps(message), qos)


### PR DESCRIPTION
Adds `qos` to the example config (already supported for subscribing), as well as to publishing (same workflow as subscribing, user can set `qos` in config, else default is 1).