### PR TITLE
add KPI framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,23 @@ pywis-pubsub ets validate https://example.org/path/to/file.json
 
 # validate WNM against abstract test suite (URL), but turn JSON Schema validation off
 pywis-pubsub ets validate https://example.org/path/to/file.json --no-fail-on-schema-validation
+
+# key performance indicators
+
+# set environment variable for GDC URL
+export PYWIS_PUBSUB_GDC_URL=https://api.weather.gc.ca/collections/wis2-discovery-metadata
+
+# all key performance indicators at once
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG
+
+# all key performance indicators at once, but turn ETS validation off
+pywis-pubsub kpi validate https://example.org/path/to/file.json --no-fail-on-ets --verbosity DEBUG
+
+# all key performance indicators at once, in summary
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG --summary
+
+# selected key performance indicator
+pywis-pubsub kpi validate --kpi metadata_id /path/to/file.json -v INFO
 ```
 
 ### Publishing
@@ -133,8 +150,8 @@ pywis-pubsub publish --topic origin/a/wis2/centre-id/data/core/weather --config 
 
 Python examples:
 
+Subscribing to a WIS2 Global Broker
 ```python
-# subscriber example
 from pywis_pubsub.mqtt import MQTTPubSubClient
 
 options = {
@@ -153,9 +170,8 @@ m = MQTTPubSubClient('mqtt://localhost:1883', options)
 m.sub(topics)
 ```
 
+Publishing a WIS2 Notification Message
 ```python
-# publish example
-
 from datetime import datetime, timezone
 
 from pywis_pubsub.mqtt import MQTTPubSubClient
@@ -173,8 +189,19 @@ message = create_message(
         operation='update'
 )
 
-m = MQTTPubSubClient('mqtt://localhost:1883')
-m.pub(topic, json.dumps(message))
+m = MQTTPubSubClient('mqtt://localhost:1883') m.pub(topic, json.dumps(message))
+```
+
+Running KPIs
+```pycon
+>>> # test KPI
+>>> import json
+>>> from pywis_pubsub.kpi import WNMKeyPerformanceIndicators
+>>> with open('/path/to/file.json') as fh:
+...     data = json.load(fh)
+>>> kpis = WNMKeyPerformanceIndicators(data)
+>>> results = kpis.evaluate()
+>>> results['summary']
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ message = create_message(
         operation='update'
 )
 
-m = MQTTPubSubClient('mqtt://localhost:1883') m.pub(topic, json.dumps(message))
+m = MQTTPubSubClient('mqtt://localhost:1883')
+m.pub(topic, json.dumps(message))
 ```
 
 Running KPIs

--- a/pywis_pubsub/__init__.py
+++ b/pywis_pubsub/__init__.py
@@ -24,6 +24,7 @@ __version__ = '0.7.dev0'
 import click
 
 from pywis_pubsub.ets import ets
+from pywis_pubsub.kpi import kpi
 from pywis_pubsub.publish import publish
 from pywis_pubsub.schema import schema
 from pywis_pubsub.subscribe import subscribe
@@ -51,6 +52,7 @@ message.add_command(verify)
 
 cli.add_command(message)
 cli.add_command(ets)
+cli.add_command(kpi)
 cli.add_command(publish)
 cli.add_command(schema)
 cli.add_command(subscribe)

--- a/pywis_pubsub/kpi.py
+++ b/pywis_pubsub/kpi.py
@@ -1,0 +1,277 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+# WIS2 Notification Message Key Performance Indicators (KPIs)
+
+import json
+import logging
+import os
+
+import click
+import requests
+
+from pywis_pubsub.ets import WNMTestSuite
+from pywis_pubsub .util import (get_cli_common_options,
+                                get_current_datetime_rfc3339, urlopen_)
+
+LOGGER = logging.getLogger(__name__)
+
+ROUND = 3
+
+
+class WNMKeyPerformanceIndicators:
+    """Key Performance Indicators for WIS2 Notification Message"""
+
+    def __init__(self, data):
+        """
+        initializer
+
+        :param data: dict of WNM JSON
+
+        :returns: `pywis_pubsub.kpi.WNMKeyPerformanceIndicators`
+        """
+
+        self.data = data
+        self.codelists = None
+
+    @property
+    def identifier(self):
+        """
+        Helper function to derive a notification identifier
+
+        :returns: notification identifier
+        """
+
+        return self.data['id']
+
+    def kpi_metadata_id(self) -> tuple:
+        """
+        Implements KPI for Metadata identifier
+
+        :returns: `tuple` of KPI name, achieved score, total score,
+                  and comments
+        """
+
+        total = 2
+        score = 0
+        comments = []
+
+        name = 'KPI: Metadata identifier'
+
+        LOGGER.info(f'Running {name}')
+
+        if 'metadata_id' in self.data['properties']:
+            score += 1
+
+            metadata_id = self.data['properties']['metadata_id']
+
+            gdc_url = os.environ.get('PYWIS_PUBSUB_GDC_URL')
+
+            if gdc_url is None:
+                msg = 'PYWIS_PUBSUB_GDC_URL environment variable not set'
+                raise RuntimeError(msg)
+
+            url = f'{gdc_url}/collections/wis2-discovery-metadata/items/{metadata_id}'  # noqa
+
+            LOGGER.debug(f'Checking for discovery metadata at {url}')
+            response = requests.get(url)
+            try:
+                response.raise_for_status()
+                score += 1
+            except requests.exceptions.HTTPError:
+                comments.append(f'Discovery metadata not found at {url}')
+        else:
+            comments.append('No metadata identifier found in notification')
+
+        return name, total, score, comments
+
+    def evaluate(self, kpi: str = None) -> dict:
+        """
+        Convenience function to run all tests
+
+        :param kpi: `str` of KPI identifier
+
+        :returns: `dict` of overall test report
+        """
+
+        kpis_to_run = []
+
+        for f in dir(WNMKeyPerformanceIndicators):
+            if all([
+                    callable(getattr(WNMKeyPerformanceIndicators, f)),
+                    f.startswith('kpi_')]):
+
+                kpis_to_run.append(f)
+
+        if kpi is not None:
+            selected_kpi = f'kpi_{kpi}'
+            if selected_kpi not in kpis_to_run:
+                msg = f'Invalid KPI number: {selected_kpi} is not in {kpis_to_run}'  # noqa
+                LOGGER.error(msg)
+                raise ValueError(msg)
+            else:
+                kpis_to_run = [selected_kpi]
+
+        LOGGER.info(f'Evaluating KPIs: {kpis_to_run}')
+
+        results = {}
+
+        for kpi in kpis_to_run:
+            LOGGER.debug(f'Running {kpi}')
+            result = getattr(self, kpi)()
+            LOGGER.debug(f'Raw result: {result}')
+            LOGGER.debug('Calculating result')
+            try:
+                percentage = round(float((result[2] / result[1]) * 100), ROUND)
+            except ZeroDivisionError:
+                percentage = None
+
+            results[kpi] = {
+                'name': result[0],
+                'total': result[1],
+                'score': result[2],
+                'comments': result[3],
+                'percentage': percentage
+            }
+            LOGGER.debug(f'{kpi}: {result[1]} / {result[2]} = {percentage}')
+
+        LOGGER.debug('Calculating total results')
+        results['summary'] = generate_summary(results)
+        results['summary']['identifier'] = self.identifier
+        overall_grade = 'F'
+        overall_grade = calculate_grade(results['summary']['percentage'])
+        results['summary']['grade'] = overall_grade
+
+        results['datetime'] = get_current_datetime_rfc3339()
+
+        return results
+
+
+def generate_summary(results: dict) -> dict:
+    """
+    Generates a summary entry for given group of results
+
+    :param results: results to generate the summary from
+
+    :returns: `dict` of summary report
+    """
+
+    sum_total = sum(v['total'] for v in results.values())
+    sum_score = sum(v['score'] for v in results.values())
+    comments = {k: v['comments'] for k, v in results.items() if v['comments']}
+
+    try:
+        sum_percentage = round(float((sum_score / sum_total) * 100), ROUND)
+    except ZeroDivisionError:
+        sum_percentage = None
+
+    summary = {
+        'total': sum_total,
+        'score': sum_score,
+        'comments': comments,
+        'percentage': sum_percentage,
+    }
+
+    return summary
+
+
+def calculate_grade(percentage: float) -> str:
+    """
+    Calculates letter grade from numerical score
+
+    :param percentage: float between 0-100
+
+    :returns: `str` of calculated letter grade
+    """
+
+    if percentage is None:
+        grade = None
+    elif percentage > 100 or percentage < 0:
+        raise ValueError('Invalid percentage')
+    elif percentage >= 80:
+        grade = 'A'
+    elif percentage >= 65:
+        grade = 'B'
+    elif percentage >= 50:
+        grade = 'C'
+    elif percentage >= 35:
+        grade = 'D'
+    elif percentage >= 20:
+        grade = 'E'
+    else:
+        grade = percentage
+
+    return grade
+
+
+@click.group()
+def kpi():
+    """key performance indicators"""
+    pass
+
+
+@click.command()
+@click.pass_context
+@get_cli_common_options
+@click.argument('file_or_url')
+@click.option('--fail-on-ets/--no-fail-on-ets',
+              '-f', default=True, help='Stop the KPI on failing ETS')
+@click.option('--summary', '-s', is_flag=True, default=False,
+              help='Provide summary of KPI test results')
+@click.option('--kpi', '-k', help='KPI to run, default is all')
+def validate(ctx, file_or_url, logfile, verbosity, kpi, summary,
+             fail_on_ets=True):
+    """run key performance indicators"""
+
+    click.echo(f'Opening {file_or_url}')
+
+    if file_or_url.startswith('http'):
+        content = urlopen_(file_or_url).read()
+    else:
+        with open(file_or_url) as fh:
+            content = fh.read()
+
+    content = json.loads(content)
+    click.echo(f'Validating {file_or_url}')
+
+    if fail_on_ets:
+        ts = WNMTestSuite(content)
+        try:
+            _ = ts.run_tests(fail_on_ets)
+        except Exception as err:
+            raise click.ClickException(err)
+            ctx.exit(1)
+
+    kpis = WNMKeyPerformanceIndicators(content)
+
+    try:
+        kpis_results = kpis.evaluate(kpi)
+    except ValueError as err:
+        raise click.UsageError(f'Invalid KPI {kpi}: {err}')
+        ctx.exit(1)
+
+    if not summary or kpi is not None:
+        click.echo(json.dumps(kpis_results, indent=4))
+    else:
+        click.echo(json.dumps(kpis_results['summary'], indent=4))
+
+
+kpi.add_command(validate)

--- a/pywis_pubsub/util.py
+++ b/pywis_pubsub/util.py
@@ -256,4 +256,4 @@ def get_current_datetime_rfc3339() -> str:
     :returns: `str` of RFC3339 datetime
     """
 
-    datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%ST')
+    datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')

--- a/pywis_pubsub/util.py
+++ b/pywis_pubsub/util.py
@@ -20,7 +20,7 @@
 ###############################################################################
 
 from base64 import b64encode
-from datetime import date, datetime, time
+from datetime import date, datetime, time, timezone
 from decimal import Decimal
 import logging
 import mimetypes
@@ -247,3 +247,13 @@ def urlopen_(url: str):
         response = urlopen(url, context=context)
 
     return response
+
+
+def get_current_datetime_rfc3339() -> str:
+    """
+    Gets the current datetime in RFC3339 format
+
+    :returns: `str` of RFC3339 datetime
+    """
+
+    datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%ST')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 click
 jsonschema
-paho-mqtt
+paho-mqtt<2
 pyyaml
 requests
 shapely<2

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -26,6 +26,7 @@ from unittest.mock import patch
 
 from requests import Session
 from pywis_pubsub.ets import WNMTestSuite
+from pywis_pubsub.kpi import calculate_grade, WNMKeyPerformanceIndicators
 from pywis_pubsub.validation import validate_message
 from pywis_pubsub.verification import verify_data
 
@@ -125,6 +126,44 @@ class WNMETSTest(unittest.TestCase):
 
             with self.assertRaises(ValueError):
                 ts.run_tests(fail_on_schema_validation=True)
+
+
+class WNMKPITest(unittest.TestCase):
+    """WNM KPI tests of tests"""
+
+    def setUp(self):
+        """setup test fixtures, etc."""
+        pass
+
+    def tearDown(self):
+        """return to pristine state"""
+        pass
+
+    def test_kpi_evaluate(self):
+        file_ = 'test_valid.json'
+        with open(get_abspath(file_)) as fh:
+            data = json.load(fh)
+
+        kpis = WNMKeyPerformanceIndicators(data)
+
+        results = kpis.evaluate()
+
+        self.assertEqual(results['summary']['total'], 2)
+        self.assertEqual(results['summary']['score'], 0)
+        self.assertEqual(results['summary']['percentage'], 0)
+        self.assertEqual(results['summary']['grade'], 0)
+
+    def test_calculate_grade(self):
+        self.assertEqual(calculate_grade(98), 'A')
+        self.assertEqual(calculate_grade(77), 'B')
+        self.assertEqual(calculate_grade(66), 'B')
+        self.assertEqual(calculate_grade(52), 'C')
+        self.assertEqual(calculate_grade(41), 'D')
+        self.assertEqual(calculate_grade(33), 'E')
+        self.assertIsNone(calculate_grade(None))
+
+        with self.assertRaises(ValueError):
+            calculate_grade(101)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- adds KPI framework as per the WNM specification (aligns with WCMP2 KPIs and pywcmp implementation of same)
- pins paho-mqtt to `<2` given 2.0.0rc2 and forthcoming breaking changes