### PR TITLE
update ETS to check for valid id UUID

### DIFF
--- a/pywis_pubsub/ets.py
+++ b/pywis_pubsub/ets.py
@@ -23,6 +23,7 @@
 
 import json
 import logging
+from uuid import UUID
 
 import click
 from jsonschema.validators import Draft202012Validator
@@ -142,21 +143,13 @@ class WNMTestSuite:
         status = {
             'id': gen_test_id('id'),
             'code': 'PASSED',
-            'message': 'Passes given schema is compliant/valid'
         }
 
-        return status
-
-    def test_requirement_type(self):
-        """
-        Check for the existence of a valid type property.
-        """
-
-        status = {
-            'id': gen_test_id('type'),
-            'code': 'PASSED',
-            'message': 'Passes given schema is compliant/valid'
-        }
+        try:
+            UUID(self.message['id'])
+        except ValueError as err:
+            status['code'] = 'FAILED'
+            status['message'] = f'Invalid UUID: {err}'
 
         return status
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -108,7 +108,7 @@ class WNMETSTest(unittest.TestCase):
             codes = [r['code'] for r in results['ets-report']['tests']]
 
             self.assertEqual(codes.count('FAILED'), 0)
-            self.assertEqual(codes.count('PASSED'), 8)
+            self.assertEqual(codes.count('PASSED'), 7)
             self.assertEqual(codes.count('SKIPPED'), 0)
 
     def test_fail(self):
@@ -121,7 +121,7 @@ class WNMETSTest(unittest.TestCase):
             codes = [r['code'] for r in results['ets-report']['tests']]
 
             self.assertEqual(codes.count('FAILED'), 1)
-            self.assertEqual(codes.count('PASSED'), 7)
+            self.assertEqual(codes.count('PASSED'), 6)
             self.assertEqual(codes.count('SKIPPED'), 0)
 
             with self.assertRaises(ValueError):


### PR DESCRIPTION
Updates based on https://github.com/wmo-im/wis2-notification-message/pull/93
- update to check `id` is a valid UUID based on https://github.com/wmo-im/wis2-notification-message/pull/93
- remove `type` check given it is implicit within GeoJSON validation