### PR TITLE
add generated-by to reports

### DIFF
--- a/pywis_pubsub/ets.py
+++ b/pywis_pubsub/ets.py
@@ -28,6 +28,8 @@ from uuid import UUID
 import click
 from jsonschema.validators import Draft202012Validator
 
+
+import pywis_pubsub
 from pywis_pubsub.schema import MESSAGE_SCHEMA
 from pywis_pubsub.message import get_link
 from pywis_pubsub.util import (get_cli_common_options,
@@ -71,6 +73,7 @@ class WNMTestSuite:
         tests = []
         ets_report = {
             'summary': {},
+            'generated-by': f'pywis-pubsub {pywis_pubsub.__version__} (https://github.com/wmo-im/pywis-pubsub)'  # noqa
         }
 
         for f in dir(WNMTestSuite):

--- a/pywis_pubsub/kpi.py
+++ b/pywis_pubsub/kpi.py
@@ -28,6 +28,7 @@ import os
 import click
 import requests
 
+import pywis_pubsub
 from pywis_pubsub.ets import WNMTestSuite
 from pywis_pubsub .util import (get_cli_common_options,
                                 get_current_datetime_rfc3339, urlopen_)
@@ -161,6 +162,7 @@ class WNMKeyPerformanceIndicators:
         results['summary']['grade'] = overall_grade
 
         results['datetime'] = get_current_datetime_rfc3339()
+        results['generated-by'] = f'pywis-pubsub {pywis_pubsub.__version__} (https://github.com/wmo-im/pywis-pubsub)'  # noqa
 
         return results
 


### PR DESCRIPTION
As discussed at a WIS2 monitoring meeting today, given some GDCs will provide ETS and KPI reports to Global Monitoring, it might be useful to have metadata added to ETS/KPI reports to identify what tool(s) generated a given report in the GDC/WCMP2 context (cc @maaikelimper).