### PR TITLE
use new url for test-data

### DIFF
--- a/.github/workflows/test-publish-subscribe-download.yml
+++ b/.github/workflows/test-publish-subscribe-download.yml
@@ -29,7 +29,7 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-no-msg-validation.yml --download --verbosity DEBUG > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://pywis-pubsub-test.s3.eu-central-1.amazonaws.com/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4
@@ -38,7 +38,7 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download --verbosity DEBUG > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://pywis-pubsub-test.s3.eu-central-1.amazonaws.com/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4


### PR DESCRIPTION
@kurt-hectic is cleaning up S3 resources and requested we use an azure-based URL for the test-data instead