### PR TITLE
Customize MQTT Client ID Using A Parameter

### DIFF
--- a/pywis_pubsub/mqtt.py
+++ b/pywis_pubsub/mqtt.py
@@ -53,10 +53,8 @@ class MQTTPubSubClient:
 
         if options:
             self.userdata = deepcopy(options)
-            try:
-                self.client_id = f"{options['client_id']}-{random.randint(0, 1000)}"
-            except:
-                self.client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
+            client_id_prefix = options.get('client_id', 'pywis-pubsub')
+            self.client_id = f'{client_id_prefix}-{random.randint(0, 1000)}'
 
         transport = 'tcp'
         # if scheme is ws or wss, set transport to websockets

--- a/pywis_pubsub/mqtt.py
+++ b/pywis_pubsub/mqtt.py
@@ -53,6 +53,10 @@ class MQTTPubSubClient:
 
         if options:
             self.userdata = deepcopy(options)
+            try:
+                self.client_id = f"{options['client_id']}-{random.randint(0, 1000)}"
+            except:
+                self.client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
 
         transport = 'tcp'
         # if scheme is ws or wss, set transport to websockets

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -183,7 +183,7 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     config = util.yaml_load(config)
 
     broker = config.get('broker')
-    default_client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
+    default_client_id = f'pywis-pubsub'
     client_id = config.get('client_id', default_client_id)
     qos = int(config.get('qos', 1))
     subscribe_topics = config.get('subscribe_topics', [])

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -183,8 +183,8 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     config = util.yaml_load(config)
 
     broker = config.get('broker')
-    default_client_id = f'pywis-pubsub'
-    client_id = config.get('client_id', default_client_id)
+    client_id_prefix = config.get('client_id', 'pywis-pubsub')
+    client_id = f'{client_id_prefix}-{random.randint(0, 1000)}'
     qos = int(config.get('qos', 1))
     subscribe_topics = config.get('subscribe_topics', [])
     verify_certs = config.get('verify_certs', True)


### PR DESCRIPTION
Use the "client_id" parameter to set the MQTT Client ID.

>             try:
>                 self.client_id = f"{options['client_id']}-{random.randint(0, 1000)}"
>             except:
>                 self.client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
