### PR TITLE
 Antiloop implementation using Redis keys for Global Broker subscriber

### DIFF
--- a/pywis_pubsub/__init__.py
+++ b/pywis_pubsub/__init__.py
@@ -28,6 +28,7 @@ from pywis_pubsub.kpi import kpi
 from pywis_pubsub.publish import publish
 from pywis_pubsub.schema import schema
 from pywis_pubsub.subscribe import subscribe
+from pywis_pubsub.relay import relay
 from pywis_pubsub.validation import validate_
 from pywis_pubsub.verification import verify
 
@@ -56,3 +57,4 @@ cli.add_command(kpi)
 cli.add_command(publish)
 cli.add_command(schema)
 cli.add_command(subscribe)
+cli.add_command(relay)

--- a/pywis_pubsub/mqtt.py
+++ b/pywis_pubsub/mqtt.py
@@ -53,6 +53,10 @@ class MQTTPubSubClient:
 
         if options:
             self.userdata = deepcopy(options)
+            try:
+                self.client_id = f"{options['client_id']}-{random.randint(0, 1000)}"
+            except:
+                self.client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
 
         transport = 'tcp'
         # if scheme is ws or wss, set transport to websockets

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -183,7 +183,7 @@ def subscribe(ctx, config, download, bbox=[], verbosity='NOTSET'):
     config = util.yaml_load(config)
 
     broker = config.get('broker')
-    default_client_id = f'pywis-pubsub-{random.randint(0, 1000)}'
+    default_client_id = f'pywis-pubsub'
     client_id = config.get('client_id', default_client_id)
     qos = int(config.get('qos', 1))
     subscribe_topics = config.get('subscribe_topics', [])

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pyyaml
 requests
 shapely<2
 urllib3<2
+redis[hiredis]


### PR DESCRIPTION
### PyWIS PubSub "Relay" Function
PywisPubSub feature for WIS2-Node to Global-Broker message communication.  The "Realy" feature was added to PyWIS PubSub using a copy of the subscription function. The Dockerfile and the YAML configuration file are additions to support docker container operation.

### Relay Function Implementation
PyWIS PubSub subscriptions are durable connections, so the relay feature adds a durable connection to the publication broker. While Phao MQTT subscriptions inherit durable connections with "loop-forever()", the publication client is made durable by placing "reconnect()" in the "on-disconnect()" call-back. The relaying procedure is added to the end of the "on-message()" callback. Notice that "on-message()" only has subscription scope, so the secret sauce here was to pass the publication client into "on-message()" using the "userdata"

```
##Top of code context:
subclient.userdata['relay'] = pubclient
...
##"on-message" callback context:
if userdata.get('relay') is not None:
client = userdata['relay']
```

#### Relay Function Configuration
```
---
sub_broker: mqtt://everyone:everyone@wis2node:1883
pub_broker: mqtt://user:password@wis2globalbroker:1883

subscribe_topics:
    - 'origin/a/wis2/#'

verify_data: true
validate_message: true

relay:
```

#### Redis Antiloop Deduplication
Deduplication uses the Redis Keys with a TTL expiration.

```
    redisclient = userdata['redis']
    try: 
        if not redisclient.set(msg_dict['id'], centre_id, ex=3600, nx=True):
            LOGGER.info(f"WIS2 Message Exists {msg.topic} ID: {msg_dict['id']}")
            return
        else:
            LOGGER.info(f"WIS2 Message added {msg.topic} ID: {msg_dict['id']}")
```

### WIS2 Message Verification
Various WIS2 message checks based on the  Global Broker Conformance and Performance Tests

#### WIS2 Center ID Matches Message ID
Checks to ensure the WIS2-Node is publishing messages with their own ID

```
    fulltopic = re.compile(r"^origin|cache/a/wis2/([A-Za-z0-9_-]+)/data|metadata/.*$")
    brieftopic = re.compile(r"^wis2/([A-Za-z0-9_-]+)/data|metadata/.*$")
    centreonly = re.compile(r"^([A-Za-z_-]+)/data|metadata/.*$")

    if brieftopic.match(msg_dict['properties']['data_id']) is not None:
        centre_id = msg_dict['properties']['data_id'].split('/')[1]
    elif centreonly.match(msg_dict['properties']['data_id']) is not None:
        centre_id = msg_dict['properties']['data_id'].split('/')[0]
    elif fulltopic.match(msg_dict['properties']['data_id'])is not None:
        centre_id = msg_dict['properties']['data_id'].split('/')[3]
    else:
        LOGGER.error(f"Invalid Data-ID: Cannot determine Centre-ID: {msg_dict['properties']['data_id']}")
        return
    if centre_id != SUB_CENTRE_ID
        LOGGER.error(f"WIS2 message Centre-ID {centre_id} does not match WIS2 Node Centre-ID: {SUB_CENTRE_ID}")
        return
```

#### Inline Content Exceeds Size Limits
Several cases have appeared where National Centers attempt to distribute RADAR and GRIB data in-line. These greatly exceed the WIS2 mandated 4096 byte limit. Further guidance is needed for either discarding the message or preserving the message. Here we truncate the on-board data segment and preserve the message. However this breaks a rule as we're modifying a UUID signed message that does not belong to us.

```
    if 'content' in msg_dict['properties'] and 'value' in msg_dict['properties']['content']:
        inlinesize = len(msg_dict['properties']['content']['value'])
        if inlinesize > 4096:
            LOGGER.error(f'Message inline content too large. Centre: {centre_id} Size: {inlinesize}', exc_info=True)
            process_metric(userdata, "invalid_total", msg_centre_id_labels)
            msg_dict['properties']['content']['value'] = 'Inline content too long... truncated'
```

#### Missing Metadata
```
    if 'metadata_id' not in msg_dict['properties']:
        LOGGER.error(f'Message missing metadata.  Centre: {centre_id}', exc_info=True)
        process_metric(userdata, "no_metadata_total", msg_centre_id_labels)
```

#### WIS2 Message Schema Validation
Because this copies PywisPubSub Subscribe, the JSON Schema validation is included.
```
    try:
        if userdata.get('validate_message', False):
            LOGGER.debug('Validating message')
            success, errmsg = validate_message(msg_dict)
            if not success:
                LOGGER.error(f'Message is not valid. Centre: {centre_id} Error: {errmsg}', exc_info=True)
                process_metric(userdata, "invalid_total", msg_centre_id_labels)
    except RuntimeError as errmsg:
        LOGGER.error(f'Cannot validate message: {errmsg}', exc_info=True)
```
This code appears to be a one-shot schema check. What might be more useful is a full evaluation of all schema violations that provides a full summary using JSON Schema "iter_errors()"

```
schema = {<<WIS2-Schema-Here>>}
v = Draft202012Validator(schema)
for error in sorted(v.iter_errors(<<WIS2-Message-Here>>), key=str):
    print(error.message)
```
### Publishing The Global Service Message
Following successful verification the message is published to the global services unchanged. The MQTT Pub Client must be passed in by reference since the message processing is in the Sub Client scope. Meta-Programming Python gymnastics could refactor this.

```
    if userdata.get('pubclient') is not None:
        client = userdata['pubclient']
        LOGGER.debug(f"Relay detected: {userdata}")
        try:
            LOGGER.debug(f'Publishing message')
            client.pub(msg.topic, json.dumps(msg_dict, default=util.json_serial), 0)
            process_metric(userdata, "published_total", msg_centre_id_labels)
            process_metric(userdata, "last_message_timestamp", msg_centre_id_labels, round(time.time()))
        except Exception as errmsg:
            LOGGER.error(f'Relay falied {errmsg}', exc_info=True)
    else:
        LOGGER.error(f'Relay falied: no pub_client connection', exc_info=True)
```
