### PR TITLE
set default logging output to DEBUG for CLI workflows

### DIFF
--- a/.github/workflows/test-publish-subscribe-download.yml
+++ b/.github/workflows/test-publish-subscribe-download.yml
@@ -14,8 +14,7 @@ jobs:
           python-version: '3.10'
       - name: Install pywis-pubsub
         run: |
-          python3 setup.py install
-          python3 setup.py build
+          pip3 install .
           pywis-pubsub --version
           pywis-pubsub schema sync
       - name: run mosquitto container, detached
@@ -27,18 +26,18 @@ jobs:
       - name: subscribe, publish and download without message validation
         run: |
           rm -rf .github/workflows/test-data/*.bufr4
-          pywis-pubsub subscribe --config .github/workflows/test-data/sub-no-msg-validation.yml --download --verbosity DEBUG > /tmp/subscribe.log &
+          pywis-pubsub subscribe --config .github/workflows/test-data/sub-no-msg-validation.yml --download > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4
       - name: subscribe, publish and download with message validation
         run: |
           rm -rf .github/workflows/test-data/*.bufr4
-          pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download --verbosity DEBUG > /tmp/subscribe.log &
+          pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4
@@ -47,6 +46,6 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --verbosity=DEBUG --file .github/workflows/test-data/example-message.json
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --file .github/workflows/test-data/example-message.json
           sleep 1
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4

--- a/.github/workflows/test-publish-subscribe-download.yml
+++ b/.github/workflows/test-publish-subscribe-download.yml
@@ -28,7 +28,7 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-no-msg-validation.yml --download > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4
@@ -37,7 +37,7 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download > /tmp/subscribe.log &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -i WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500 -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml -u https://wmostorage.blob.core.windows.net/wmo-public/wmo-information-system/pywis-pubsub-test/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4 -g 33.8025,-11.8415 -w 0-454-2-AWSCHIKANGAWA
           sleep 1
           less /tmp/subscribe.log
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4
@@ -46,6 +46,6 @@ jobs:
           rm -rf .github/workflows/test-data/*.bufr4
           pywis-pubsub subscribe --config .github/workflows/test-data/sub-with-msg-validation.yml --download &
           sleep 1
-          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --file .github/workflows/test-data/example-message.json
+          pywis-pubsub publish --config .github/workflows/test-data/pub-config.yml --wnm .github/workflows/test-data/example-message.json
           sleep 1
           ls -lh .github/workflows/test-data/origin/a/wis2/mwi/malawi_wmo_demo/data/core/weather/surface-based-observations/synop/WIGOS_0-454-2-AWSCHIKANGAWA_20221109T135500.bufr4

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ pywis-pubsub publish --topic origin/a/wis2/centre-id/data/core/weather --config 
 pywis-pubsub publish --topic origin/a/wis2/centre-id/data/core/weather --config pub-local.yml -i stationXYZ-20221111085500 -u https://example.org/stationXYZ-20221111085500.bufr4 -g 33.8,-11.8,8.112 -w 0-20000-12345 --metadata-id "x-urn:wmo:md:test-foo:htebmal2001" --operation delete
 
 # publish a message from file on disk
-pywis-pubsub publish --topic origin/a/wis2/centre-id/data/core/weather --config pub-local.yml --file my_message.json
+pywis-pubsub publish --topic origin/a/wis2/centre-id/data/core/weather --config pub-local.yml --wnm my_message.json
 ```
 
 ### Using the API

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ pywis-pubsub subscribe --config local.yml --download
 # subscribe, and filter messages by geometry
 pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84
 
-# subscribe, and filter messages by geometry, increase debugging verbosity
-pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84 --verbosity=DEBUG
+# subscribe, and filter messages by geometry, adjust debugging verbosity
+pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84 --verbosity=INFO
 ```
 
 ### Validating a message and verifying data
@@ -101,13 +101,13 @@ pywis-pubsub ets validate https://example.org/path/to/file.json --no-fail-on-sch
 export PYWIS_PUBSUB_GDC_URL=https://api.weather.gc.ca/collections/wis2-discovery-metadata
 
 # all key performance indicators at once
-pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity INFO/
 
 # all key performance indicators at once, but turn ETS validation off
-pywis-pubsub kpi validate https://example.org/path/to/file.json --no-fail-on-ets --verbosity DEBUG
+pywis-pubsub kpi validate https://example.org/path/to/file.json --no-fail-on-ets --verbosity INFO
 
 # all key performance indicators at once, in summary
-pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG --summary
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity INFO --summary
 
 # selected key performance indicator
 pywis-pubsub kpi validate --kpi metadata_id /path/to/file.json -v INFO

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ pywis-pubsub subscribe --config local.yml --download
 pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84
 
 # subscribe, and filter messages by geometry, adjust debugging verbosity
-pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84 --verbosity=INFO
+pywis-pubsub subscribe --config local.yml --bbox=-142,42,-52,84 --verbosity=DEBUG
 ```
 
 ### Validating a message and verifying data
@@ -101,13 +101,13 @@ pywis-pubsub ets validate https://example.org/path/to/file.json --no-fail-on-sch
 export PYWIS_PUBSUB_GDC_URL=https://api.weather.gc.ca/collections/wis2-discovery-metadata
 
 # all key performance indicators at once
-pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity INFO/
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG
 
 # all key performance indicators at once, but turn ETS validation off
-pywis-pubsub kpi validate https://example.org/path/to/file.json --no-fail-on-ets --verbosity INFO
+pywis-pubsub kpi validate https://example.org/path/to/file.json --no-fail-on-ets --verbosity DEBUG
 
 # all key performance indicators at once, in summary
-pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity INFO --summary
+pywis-pubsub kpi validate https://example.org/path/to/file.json --verbosity DEBUG --summary
 
 # selected key performance indicator
 pywis-pubsub kpi validate --kpi metadata_id /path/to/file.json -v INFO

--- a/pywis_pubsub/cli_options.py
+++ b/pywis_pubsub/cli_options.py
@@ -34,9 +34,9 @@ def OPTION_VERBOSITY(f):
     logging_options = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
 
     def callback(ctx, param, value):
-        if value is not None:
-            logging.basicConfig(stream=sys.stdout,
-                                level=getattr(logging, value))
+        value2 = value or 'DEBUG'
+        logging.basicConfig(stream=sys.stdout,
+                            level=getattr(logging, value2))
         return True
 
     return click.option('--verbosity', '-v',

--- a/pywis_pubsub/cli_options.py
+++ b/pywis_pubsub/cli_options.py
@@ -34,7 +34,7 @@ def OPTION_VERBOSITY(f):
     logging_options = ['ERROR', 'WARNING', 'INFO', 'DEBUG']
 
     def callback(ctx, param, value):
-        value2 = value or 'DEBUG'
+        value2 = value or 'INFO'
         logging.basicConfig(stream=sys.stdout,
                             level=getattr(logging, value2))
         return True

--- a/pywis_pubsub/publish.py
+++ b/pywis_pubsub/publish.py
@@ -219,7 +219,7 @@ def create_message(topic: str, content_type: str, url: str, identifier: str,
               help='WIGOS station identifier')
 @click.option('--operation', '-op', type=click.Choice(LINK_TYPES.keys()),
               default='create', help='message operation')
-def publish(ctx, wnm_, config, url, topic, datetime_,
+def publish(ctx, wnm, config, url, topic, datetime_,
             inline=False, geometry=[], metadata_id=None,
             wigos_station_identifier=None, operation='create',
             verbosity='NOTSET'):

--- a/pywis_pubsub/publish.py
+++ b/pywis_pubsub/publish.py
@@ -209,7 +209,6 @@ def create_message(topic: str, content_type: str, url: str, identifier: str,
 @click.option('--identifier', '-i', help='unique file identifier')
 @click.option('--inline', '-in', default=False,
               help='whether to publish the data inline as base64 (default=False)')  # noqa
-@click.option('--topic', '-t', help='topic to publish to')
 @click.option('--datetime', '-d', 'datetime_',
               help='Datetime instant or extent')
 @click.option('--topic', '-t', help='topic to publish to')

--- a/pywis_pubsub/publish.py
+++ b/pywis_pubsub/publish.py
@@ -205,7 +205,7 @@ def create_message(topic: str, content_type: str, url: str, identifier: str,
 @click.pass_context
 @cli_options.OPTION_CONFIG
 @cli_options.OPTION_VERBOSITY
-@click.option('--wnm', '-w', type=click.File(), help='url of data')
+@click.option('--wnm', '-wnm', type=click.File(), help='url of data')
 @click.option('--url', '-u', help='url of data')
 @click.option('--inline', '-in', default=False,
               help='whether to publish the data inline as base64 (default=False)')  # noqa

--- a/pywis_pubsub/publish.py
+++ b/pywis_pubsub/publish.py
@@ -256,13 +256,13 @@ def publish(ctx, file_, config, url, topic, datetime_, identifier,
                 start, end = datetime_.split('/')
                 if start:
                     start_datetime = datetime.strptime(
-                        start, '%Y-%m-%dT%H:%M:%S%Z')
+                        start, '%Y-%m-%dT%H:%M:%SZ')
                 if end:
                     end_datetime = datetime.strptime(
-                        end, '%Y-%m-%dT%H:%M:%S%Z')
+                        end, '%Y-%m-%dT%H:%M:%SZ')
             else:
                 datetime_2 = datetime.strptime(
-                    datetime_, '%Y-%m-%dT%H:%M:%S%Z')
+                    datetime_, '%Y-%m-%dT%H:%M:%SZ')
 
         message = create_message(
             topic=topic2,

--- a/pywis_pubsub/subscribe.py
+++ b/pywis_pubsub/subscribe.py
@@ -43,8 +43,8 @@ LOGGER = logging.getLogger(__name__)
 def on_message_handler(client, userdata, msg):
     """message handler"""
 
-    LOGGER.debug(f'Topic: {msg.topic}')
-    LOGGER.debug(f'Message:\n{msg.payload}')
+    LOGGER.info(f'Topic: {msg.topic}')
+    LOGGER.info(f'Message:\n{msg.payload}')
 
     msg_dict = json.loads(msg.payload)
 


### PR DESCRIPTION
This PR makes CLI workflows emit increased output on subscription, topic and messages to the console.

cc @6a6d74

Additional fixes on publishing via CLI:
- remove duplicate `--topic` CLI option
- fix time parsing for ``--datetime``
- remove ``--identifier`` for CLI publishing workflows
- rename ``--file`` to ``--wnm`` for CLI publishing workflows of WNMs