### PR TITLE
add raise_for_status() to ETS testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ from datetime import datetime, timezone
 
 from pywis_pubsub.mqtt import MQTTPubSubClient
 from pywis_pubsub.publish import create_message
+from pywis_pubsub.ets import WNMTestSuite, WNMKeyPerformanceIndicators
 
 message = create_message(
         topic='foo/bar',
@@ -197,6 +198,9 @@ m.pub(topic, json.dumps(message))
 
 Running KPIs
 ```pycon
+>>> ts = WNMTestSuite(message)
+>>> ts.run_tests()  # raises ValueError error stack on exception
+>>> ts.raise_for_status()  # raises pywis_pubsub.errors.TestSuiteError on exception with list of errors captured in .errors property
 >>> # test KPI
 >>> import json
 >>> from pywis_pubsub.kpi import WNMKeyPerformanceIndicators

--- a/pywis_pubsub/errors.py
+++ b/pywis_pubsub/errors.py
@@ -1,0 +1,27 @@
+###############################################################################
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+###############################################################################
+
+class TestSuiteError(Exception):
+    """custom exception handler"""
+    def __init__(self, message, errors):
+        """set error list/stack"""
+        super(TestSuiteError, self).__init__(message)
+        self.errors = errors

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -25,6 +25,7 @@ import unittest
 from unittest.mock import patch
 
 from requests import Session
+from pywis_pubsub.errors import TestSuiteError
 from pywis_pubsub.ets import WNMTestSuite
 from pywis_pubsub.kpi import calculate_grade, WNMKeyPerformanceIndicators
 from pywis_pubsub.verification import verify_data
@@ -125,6 +126,22 @@ class WNMETSTest(unittest.TestCase):
                 record = json.load(fh)
                 ts = WNMTestSuite(record)
                 results = ts.run_tests()
+
+    def test_raise_for_status(self):
+        """Simple test for raise_for_status"""
+
+        with open(get_abspath('test_valid.json')) as fh:
+            ts = WNMTestSuite(json.load(fh))
+            _ = ts.run_tests(fail_on_schema_validation=True)
+
+            assert ts.raise_for_status() is None
+
+        with open(get_abspath('test_invalid_uuid.json')) as fh:
+            ts = WNMTestSuite(json.load(fh))
+            _ = ts.run_tests(fail_on_schema_validation=True)
+
+            with self.assertRaises(TestSuiteError):
+                ts.raise_for_status()
 
 
 class WNMKPITest(unittest.TestCase):

--- a/tests/test_invalid_uuid.json
+++ b/tests/test_invalid_uuid.json
@@ -1,0 +1,35 @@
+{
+    "id": "this is not a UUID",
+    "conformsTo": [
+        "http://wis.wmo.int/spec/wnm/1/conf/core"
+    ],
+    "type": "Feature",
+    "geometry": {
+        "type": "Point",
+        "coordinates": [
+            6.146255135536194,
+            46.223296618227444
+        ]
+    },
+    "properties": {
+        "pubtime": "2022-03-20T04:50:18.314854383Z",
+        "datetime": "2022-03-20T04:45:00Z",
+        "integrity": {
+            "method": "sha512",
+            "value": "A2KNxvks...S8qfSCw=="
+        },
+        "data_id": "wis2/CAN/eccc-msc/data/core/weather/surface-based-obs/landFixed/UANT01_CWAO_200445___15103.bufr4",
+        "content": {
+            "encoding": "utf-8",
+            "value": "encoded bytes from the file",
+            "size": 457
+        }
+    },
+    "links": [
+        {
+            "href": "https://example.org/data/4Pubsub/92c557ef-d28e-4713-91af-2e2e7be6f8ab.bufr4",
+            "rel": "canonical",
+            "type": "application/bufr"
+        }
+    ]
+}


### PR DESCRIPTION
The move from schema validation to ETS handling was missing a `raise_for_status()` trigger as an optional function to support downstream applications.